### PR TITLE
Extract todoIcon constant in HomeView

### DIFF
--- a/voiceRecorder/Presentation/Home/HomeView.swift
+++ b/voiceRecorder/Presentation/Home/HomeView.swift
@@ -10,14 +10,14 @@ import SwiftUI
 struct HomeView: View {
     @EnvironmentObject private var pathModel: PathModel
     @StateObject private var homeViewModel = HomeViewModel()
-    
+    private let todoIcon = "todoIcon"
     var body: some View {
         ZStack {
             TabView(selection: $homeViewModel.selectedTab) {
                 TodoListView()
                     .tabItem {
                         Image(
-                            homeViewModel.selectedTab == .todoList ? "todoIcon_selected" : "todoIcon"
+                            homeViewModel.selectedTab == .todoList ? "todoIcon_selected" : todoIcon
                         )
                     }.tag(Tab.todoList)
                 


### PR DESCRIPTION
### TL;DR
Extracted the todo icon string into a constant to improve code maintainability.

### What changed?
Created a private constant `todoIcon` to store the image name "todoIcon" and updated the tab item's Image reference to use this constant.

### How to test?
1. Launch the app
2. Verify the todo icon appears correctly in the tab bar
3. Switch between tabs to ensure the selected/unselected states display properly

### Why make this change?
Extracting the string literal into a constant reduces the risk of typos and makes future icon name updates easier to maintain by centralizing the value in one location.